### PR TITLE
fix: fix HTMLElement is not defined on SSR

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1,6 +1,8 @@
 // src/magic.ts
 var wait = (time = 0) => new Promise((r) => setTimeout(r, time));
 function install() {
+  if (typeof HTMLElement === "undefined")
+    return;
   class MagicImg extends HTMLElement {
     initial = false;
     width = 0;

--- a/src/magic.ts
+++ b/src/magic.ts
@@ -1,6 +1,8 @@
 const wait = (time = 0) => new Promise((r) => setTimeout(r, time))
 
 export function install() {
+  if (typeof HTMLElement === 'undefined') return
+
   class MagicImg extends HTMLElement {
     initial = false
     width = 0


### PR DESCRIPTION
我是在用 VuePress 2 + Vite 使用這個套件的，在執行 `vuepress build` 時 (運行在 SSR 環境) 會回報以下錯誤，而這個 PR 是修復這個錯誤的：

```
ReferenceError: HTMLElement is not defined
    at install (file:///D:/my-project/node_modules/magic-img/dist/index.mjs:4:26)
```

因為在 SSR 的時候是在 Node 運行，不存在 HTMLElement 而導致錯誤，只要在 HTMLElement 不存在時停止執行就可以了，而瀏覽器端還是可以正常的。